### PR TITLE
adds link to todo issues repo to issue text

### DIFF
--- a/.github/scripts/build-helpers/clean.js
+++ b/.github/scripts/build-helpers/clean.js
@@ -4,10 +4,23 @@ const { directories } = require('./utils');
 
 const thingsToDelete = ['./dist'];
 
+async function exists(f) {
+  try {
+    await fs.promises.stat(f);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 (async function() {
   for(const thing of thingsToDelete) {
     process.stdout.write(`[clean] deleting ${thing}...`);
-    await fs.rm(path.resolve(directories.root, thing), { recursive: true });
+    const directory = path.resolve(directories.root, thing);
+    if (await exists(directory)) {
+      await fs.rm(directory, { recursive: true });
+    }
+
     process.stdout.write(`done!\n`);
   }
 })();

--- a/dist/.template.eta
+++ b/dist/.template.eta
@@ -8,6 +8,7 @@
 //end todo-issue
 -->
 
+The following **<%= it.type.matchText %>** comment was found in `<%= it.filePath %>` on line <%= it.line %>.
 <% if (it.surroundingCode) { %>
 ```<%~ it.languageCode %>
 <%~ it.surroundingCode %>
@@ -15,4 +16,4 @@
 <% } %>
 
 ---
-_This issue has been automatically created based on a code comment found in [<%= it.relativeFilePath %> on line <%= it.line %>](<%= it.githubUrl %>). It will automatically be closed when the above comment is removed from the default branch._
+_This issue has been automatically created by <%= it.todoIssuesLink %> based on a code comment found in [<%= it.relativeFilePath %> on line <%= it.line %>](<%= it.githubUrl %>). It will automatically be closed when the above comment is removed from the default branch._

--- a/dist/index.js
+++ b/dist/index.js
@@ -57967,6 +57967,8 @@ const fs_1 = __importDefault(__nccwpck_require__(7147));
 const linguist_language_map_1 = __nccwpck_require__(3924);
 const logger_1 = __nccwpck_require__(4636);
 const repository_context_1 = __nccwpck_require__(3451);
+const pkg = __importStar(__nccwpck_require__(4147));
+const { version, name, homepage } = pkg;
 const templateFile = path_1.default.resolve(__dirname, './.template.eta');
 const templateContents = fs_1.default.readFileSync(templateFile).toString();
 const metadataStartMarker = '//start todo-issue';
@@ -57983,6 +57985,8 @@ const formatIssueText = async (todo) => {
     const props = {
         languageCode: await (0, linguist_language_map_1.getCodeForExtension)(ext) || '',
         relativeFilePath,
+        version,
+        todoIssuesLink: `[${name} v${version}](${homepage})`,
         githubUrl: `https://github.com/${repoContext.repositoryOwner}/${repoContext.repositoryName}/blob/${repoContext.defaultBranch}/${relativeFilePath}#L${todo.line}`
     };
     const text = Eta.render(templateContents, { ...todo, ...props, ...repoContext });
@@ -61481,6 +61485,14 @@ module.exports = parseParams
 }));
 //# sourceMappingURL=eta.umd.js.map
 
+
+/***/ }),
+
+/***/ 4147:
+/***/ ((module) => {
+
+"use strict";
+module.exports = JSON.parse('{"name":"todo-issues","version":"1.1.0","description":"","private":true,"author":"Jared Barboza","license":"MIT","repository":{"type":"git","url":"git+https://github.com/troublecatstudios/todo-issues.git"},"bugs":{"url":"https://github.com/troublecatstudios/todo-issues/issues"},"homepage":"https://github.com/troublecatstudios/todo-issues#readme","main":"./dist/index.js","scripts":{"test":"jest --no-cache","build":"yarn clean && npm run package && yarn copy","version":"yarn run build","ci":"yarn run build && yarn test --coverage","cli":"node ./bin/cli.js","copy":"node ./.github/scripts/build-helpers/copy.js","clean":"node ./.github/scripts/build-helpers/clean.js","package":"ncc build src/index.ts --license licenses.txt","package:watch":"npm run package -- --watch"},"exports":{".":"./dist/index.js"},"engines":{"node":">=18"},"devDependencies":{"@actions/exec":"^1.1.1","@kie/mock-github":"^2.0.1","@types/jest":"^27.4.1","@types/js-yaml":"^4.0.5","@types/node":"^20.1.4","@types/prismjs":"^1.26.0","@vercel/ncc":"^0.38.1","esbuild":"^0.20.0","jest":"^27.5.1","nock":"^14.0.0-beta.2","ts-jest":"^27.1.4","ts-node":"^10.9.1","typescript":"^4.9.5"},"dependencies":{"@actions/core":"^1.10.0","@actions/github":"^6.0.0","@actions/glob":"^0.4.0","@actions/io":"^1.1.3","@octokit/plugin-retry":"^3.0.9","@octokit/plugin-throttling":"^5.2.1","@octokit/rest":"^19.0.7","@octokit/webhooks-definitions":"^3.67.3","eta":"^2.0.1","js-yaml":"^4.1.0","linguist":"https://github.com/github/linguist#v7.30.0","prismjs":"^1.28.0"}}');
 
 /***/ })
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "todo-issues",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "description": "",
   "private": true,
   "author": "Jared Barboza",

--- a/src/__fixtures__/cases/01_basic-comment.issue.txt
+++ b/src/__fixtures__/cases/01_basic-comment.issue.txt
@@ -1,0 +1,23 @@
+<!-- todo-issue comment block, do not remove
+//start todo-issue
+{
+  "hash": "abcde",
+  "filePath": "/src/file.js",
+  "line": 1
+}
+//end todo-issue
+-->
+
+The following **TODO** comment was found in `/src/file.js` on line 1.
+
+```js
+// TODO: convert this to typescript
+function add() {
+  var i = 0;
+  for(var x of arguments) {
+    i += x;
+```
+
+
+---
+_This issue has been automatically created by [todo-issues v1.0.0](https://github.com/troublecatstudios/todo-issues#readme) based on a code comment found in [file.js on line 1](https://github.com/test/repo/blob/main/file.js#L1). It will automatically be closed when the above comment is removed from the default branch._

--- a/src/__fixtures__/cases/01_basic-comment.issue.txt
+++ b/src/__fixtures__/cases/01_basic-comment.issue.txt
@@ -20,4 +20,4 @@ function add() {
 
 
 ---
-_This issue has been automatically created by [todo-issues v1.0.0](https://github.com/troublecatstudios/todo-issues#readme) based on a code comment found in [file.js on line 1](https://github.com/test/repo/blob/main/file.js#L1). It will automatically be closed when the above comment is removed from the default branch._
+_This issue has been automatically created by [todo-issues v1.1.0](https://github.com/troublecatstudios/todo-issues#readme) based on a code comment found in [file.js on line 1](https://github.com/test/repo/blob/main/file.js#L1). It will automatically be closed when the above comment is removed from the default branch._

--- a/src/__tests__/fixture-helper.ts
+++ b/src/__tests__/fixture-helper.ts
@@ -1,5 +1,11 @@
+import { readFile } from 'fs/promises';
 import { resolve } from "path";
 
-export const fixture = (filePath: string): string =>  {
+export const fixture = (filePath: string): string => {
   return resolve(__dirname, `../__fixtures__`, filePath);
+};
+
+export const readFixture = async (filePath: string): Promise<Buffer> => {
+  const buffer = await readFile(fixture(filePath));
+  return buffer;
 };

--- a/src/__tests__/test-helpers.ts
+++ b/src/__tests__/test-helpers.ts
@@ -8,3 +8,7 @@ export const normalizeNewLines = (input: string): string => {
 export const normalizeString = (input: string): string => {
   return normalizeNewLines(input).trim();
 };
+
+export const removeWhitespace = (input: string): string => {
+  return input.replace(/\s/ig, '');
+}

--- a/src/issues/.template.eta
+++ b/src/issues/.template.eta
@@ -8,6 +8,7 @@
 //end todo-issue
 -->
 
+The following **<%= it.type.matchText %>** comment was found in `<%= it.filePath %>` on line <%= it.line %>.
 <% if (it.surroundingCode) { %>
 ```<%~ it.languageCode %>
 <%~ it.surroundingCode %>
@@ -15,4 +16,4 @@
 <% } %>
 
 ---
-_This issue has been automatically created based on a code comment found in [<%= it.relativeFilePath %> on line <%= it.line %>](<%= it.githubUrl %>). It will automatically be closed when the above comment is removed from the default branch._
+_This issue has been automatically created by <%= it.todoIssuesLink %> based on a code comment found in [<%= it.relativeFilePath %> on line <%= it.line %>](<%= it.githubUrl %>). It will automatically be closed when the above comment is removed from the default branch._

--- a/src/issues/__tests__/formatter.tests.ts
+++ b/src/issues/__tests__/formatter.tests.ts
@@ -2,6 +2,8 @@ import { formatIssueText, getTodoIssueMetadata } from '../formatter';
 import { CommentMarker, ITodo } from '../../todo-parser';
 import { issueBodyWithInvalidJSON, issueBodyWithMissingMetadataFields, issueBodyWithNoMetadata, issueBodyWithValidMetadata } from './createFakeGitHubIssue';
 import { setRepositoryContext } from '../../__mocks__/repository-context';
+import { readFixture } from '../../__tests__/fixture-helper';
+import { normalizeString } from '../../__tests__/test-helpers';
 
 
 describe('getTodoIssueMetadata', () => {
@@ -120,8 +122,8 @@ describe('formatIssueText', () => {
 
   it('should include a URL to the comment line within GitHub', async () => {
     const defaultBranch = 'main',
-          repositoryName = 'todo-issues',
-          repositoryOwner = 'troublecatstudios';
+      repositoryName = 'todo-issues',
+      repositoryOwner = 'troublecatstudios';
     setRepositoryContext({ defaultBranch, repositoryName, repositoryOwner });
     const todo: ITodo = {
       line: 10,
@@ -140,9 +142,9 @@ describe('formatIssueText', () => {
 
   it('should include the relative path to the file', async () => {
     const workingDirectory = '/some/absolute',
-          defaultBranch = 'main',
-          repositoryName = 'todo-issues',
-          repositoryOwner = 'troublecatstudios';
+      defaultBranch = 'main',
+      repositoryName = 'todo-issues',
+      repositoryOwner = 'troublecatstudios';
     setRepositoryContext({ defaultBranch, repositoryName, repositoryOwner, workingDirectory });
     const todo: ITodo = {
       line: 10,
@@ -158,6 +160,33 @@ describe('formatIssueText', () => {
     const body = await formatIssueText(todo);
     expect(body).toContain(expectedPath);
     expect(body).toContain(`[${expectedPath} on line ${todo.line}]`);
+  });
+
+  it('should generate issue text that matches the .template.eta template', async () => {
+    const workingDirectory = '/src',
+      defaultBranch = 'main',
+      repositoryName = 'repo',
+      repositoryOwner = 'test',
+      expectedIssueBody = (await readFixture(`./cases/01_basic-comment.issue.txt`)).toString();
+    setRepositoryContext({ defaultBranch, repositoryName, repositoryOwner, workingDirectory });
+    const todo: ITodo = {
+      line: 1,
+      hash: 'abcde',
+      title: '',
+      issue: '',
+      type: new CommentMarker('TODO'),
+      filePath: '/src/file.js',
+      endLine: 5,
+      surroundingCode: [
+        '// TODO: convert this to typescript',
+        'function add() {',
+        '  var i = 0;',
+        '  for(var x of arguments) {',
+        '    i += x;',
+      ].join('\n')
+    };
+    const body = await formatIssueText(todo);
+    expect(normalizeString(body)).toBe(normalizeString(expectedIssueBody));
   });
 
   // it should return a github issue payload { reference?, title, body }

--- a/src/issues/formatter.ts
+++ b/src/issues/formatter.ts
@@ -5,6 +5,9 @@ import fs from 'fs';
 import { getCodeForExtension } from './linguist-language-map';
 import { error } from '../logger';
 import { getRepositoryContext } from '../repository-context';
+import * as pkg from './../../package.json';
+
+const { version, name, homepage } = pkg;
 
 const templateFile = path.resolve(__dirname, './.template.eta');
 const templateContents = fs.readFileSync(templateFile).toString();
@@ -31,6 +34,8 @@ export const formatIssueText = async (todo: ITodo): Promise<string> => {
   const props = {
     languageCode: await getCodeForExtension(ext) || '',
     relativeFilePath,
+    version,
+    todoIssuesLink: `[${name} v${version}](${homepage})`,
     githubUrl: `https://github.com/${repoContext.repositoryOwner}/${repoContext.repositoryName}/blob/${repoContext.defaultBranch}/${relativeFilePath}#L${todo.line}`
   };
   const text = Eta.render(templateContents, { ...todo, ...props, ...repoContext });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "sourceMap": true,
     "esModuleInterop": true,
     "removeComments": true,
-    "resolveJsonModule": true,
+    "resolveJsonModule": false,
     "noImplicitAny": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -1,0 +1,1 @@
+declare module "*.json";


### PR DESCRIPTION
### Changed 

Adds the following bits of information within the created issue text

- The todo-issues version
- A link back to todo-issues repo
- The file path and line number where the comment was found. This was already included, but it's been added to the beginning of the issue text.